### PR TITLE
Add support for link_attributes in menues

### DIFF
--- a/templates/menu/menu--account.html.twig
+++ b/templates/menu/menu--account.html.twig
@@ -1,0 +1,50 @@
+{#
+/**
+ * @file
+ * Bootstrap Barrio's override to display Menu Account.
+ *
+ * Available variables:
+ * - menu_name: The machine name of the menu.
+ * - items: A nested list of menu items. Each menu item contains:
+ *   - attributes: HTML attributes for the menu item.
+ *   - below: The menu item child items.
+ *   - title: The menu link title.
+ *   - url: The menu link url, instance of \Drupal\Core\Url
+ *   - localized_options: Menu link localized options.
+ *   - is_expanded: TRUE if the link has visible children within the current
+ *     menu tree.
+ *   - is_collapsed: TRUE if the link has children within the current menu tree
+ *     that are not currently visible.
+ *   - in_active_trail: TRUE if the link is in the active trail.
+ */
+#}
+{% import _self as menus %}
+
+{#
+  We call a macro which calls itself to render the full tree.
+  @see http://twig.sensiolabs.org/doc/tags/macro.html
+#}
+{{ menus.menu_links(items, attributes, 0) }}
+
+{% macro menu_links(items, attributes, menu_level) %}
+  {% import _self as menus %}
+  {% if items %}
+    {% if menu_level == 0 %}
+      <ul{{ attributes.addClass('nav') }}>
+        {% for item in items %}
+          {% set link_classes = [
+            'nav-link',
+            item.in_active_trail ? 'active',
+          ] %}
+          {% if item.url.getOption('attributes') is not null %}
+            {% set link_attributes =  create_attribute(item.url.getOption('attributes')).addClass(link_classes) %}
+          {% else %}
+            {% set link_attributes =  create_attribute({'class': link_classes}) %}
+          {% endif %}
+
+          {{ link(item.title, item.url, link_attributes) }}
+        {% endfor %}
+      </ul>
+    {% endif %}
+  {% endif %}
+{% endmacro %}

--- a/templates/menu/menu--footer.html.twig
+++ b/templates/menu/menu--footer.html.twig
@@ -1,0 +1,67 @@
+{#
+/**
+ * @file
+ * Theme override to display a menu.
+ *
+ * Available variables:
+ * - menu_name: The machine name of the menu.
+ * - items: A nested list of menu items. Each menu item contains:
+ *   - attributes: HTML attributes for the menu item.
+ *   - below: The menu item child items.
+ *   - title: The menu link title.
+ *   - url: The menu link url, instance of \Drupal\Core\Url
+ *   - localized_options: Menu link localized options.
+ *   - is_expanded: TRUE if the link has visible children within the current
+ *     menu tree.
+ *   - is_collapsed: TRUE if the link has children within the current menu tree
+ *     that are not currently visible.
+ *   - in_active_trail: TRUE if the link is in the active trail.
+ */
+#}
+{% import _self as menus %}
+
+{#
+  We call a macro which calls itself to render the full tree.
+  @see http://twig.sensiolabs.org/doc/tags/macro.html
+#}
+{{ menus.menu_links(items, attributes, 0) }}
+
+{% macro menu_links(items, attributes, menu_level) %}
+  {% import _self as menus %}
+  {% if items %}
+    {% if menu_level == 0 %}
+      <ul{{ attributes.addClass('nav navbar-nav') }}>
+    {% else %}
+      <ul class="menu">
+    {% endif %}
+    {% for item in items %}
+      {%
+        set classes = [
+          'nav-item',
+          item.is_expanded ? 'menu-item--expanded',
+          item.is_collapsed ? 'menu-item--collapsed',
+          item.in_active_trail ? 'active',
+        ]
+      %}
+      <li{{ item.attributes.addClass(classes) }}>
+        {%
+          set link_classes = [
+            'nav-link',
+            item.in_active_trail ? 'active',
+          ]
+        %}
+        {% if item.url.getOption('attributes') is not null %}
+          {% set link_attributes =  create_attribute(item.url.getOption('attributes')).addClass(link_classes) %}
+        {% else %}
+          {% set link_attributes =  create_attribute({'class': link_classes}) %}
+        {% endif %}
+
+        {{ link(item.title, item.url, link_attributes) }}
+        {% if item.below %}
+          {{ menus.menu_links(item.below, attributes, menu_level + 1) }}
+        {% endif %}
+      </li>
+    {% endfor %}
+    </ul>
+  {% endif %}
+{% endmacro %}

--- a/templates/menu/menu--main.html.twig
+++ b/templates/menu/menu--main.html.twig
@@ -1,0 +1,68 @@
+{#
+/**
+ * @file
+ * Bootstrap Barrio's override to display a menu.
+ *
+ * Available variables:
+ * - menu_name: The machine name of the menu.
+ * - items: A nested list of menu items. Each menu item contains:
+ *   - attributes: HTML attributes for the menu item.
+ *   - below: The menu item child items.
+ *   - title: The menu link title.
+ *   - url: The menu link url, instance of \Drupal\Core\Url
+ *   - localized_options: Menu link localized options.
+ *   - is_expanded: TRUE if the link has visible children within the current
+ *     menu tree.
+ *   - is_collapsed: TRUE if the link has children within the current menu tree
+ *     that are not currently visible.
+ *   - in_active_trail: TRUE if the link is in the active trail.
+ */
+#}
+{% import _self as menus %}
+
+{#
+  We call a macro which calls itself to render the full tree.
+  @see http://twig.sensiolabs.org/doc/tags/macro.html
+#}
+{{ menus.menu_links(items, attributes, 0) }}
+
+{% macro menu_links(items, attributes, menu_level) %}
+  {% import _self as menus %}
+  {% if items %}
+    {% if menu_level == 0 %}
+<ul{{ attributes.addClass('nav navbar-nav') }}>
+  {% else %}
+  <ul class="dropdown-menu">
+    {% endif %}
+    {% for item in items %}
+      {% set classes = [
+        menu_level ? 'dropdown-item' : 'nav-item',
+        item.is_expanded ? 'menu-item--expanded',
+        item.is_collapsed ? 'menu-item--collapsed',
+        item.in_active_trail ? 'active',
+        item.below ? 'dropdown',
+      ] %}
+      <li{{ item.attributes.addClass(classes) }}>
+        {% set link_classes = [
+          not menu_level ? 'nav-link',
+          item.in_active_trail ? 'active',
+          item.below ? 'dropdown-toggle',
+        ] %}
+
+        {% if item.url.getOption('attributes') is not null %}
+          {% set link_attributes = create_attribute(item.url.getOption('attributes')).addClass(link_classes).setAttribute('data-toggle', 'dropdown').setAttribute('aria-expanded', 'false').setAttribute('aria-haspopup', 'true') %}
+        {% else %}
+          {% set link_attributes = create_attribute({'class':  link_classes , 'data-toggle': 'dropdown', 'aria-expanded': 'false', 'aria-haspopup': 'true' }) %}
+        {% endif %}
+        {% if item.below %}
+          {{ link(item.title, item.url,link_attributes) }}
+          {{ menus.menu_links(item.below, attributes, menu_level + 1) }}
+        {% else %}
+
+          {{ link(item.title, item.url, link_attributes) }}
+        {% endif %}
+      </li>
+    {% endfor %}
+  </ul>
+  {% endif %}
+  {% endmacro %}

--- a/templates/menu/menu.html.twig
+++ b/templates/menu/menu.html.twig
@@ -1,0 +1,63 @@
+{#
+/**
+ * @file
+ * Theme override to display a menu.
+ *
+ * Available variables:
+ * - menu_name: The machine name of the menu.
+ * - items: A nested list of menu items. Each menu item contains:
+ *   - attributes: HTML attributes for the menu item.
+ *   - below: The menu item child items.
+ *   - title: The menu link title.
+ *   - url: The menu link url, instance of \Drupal\Core\Url
+ *   - localized_options: Menu link localized options.
+ *   - is_expanded: TRUE if the link has visible children within the current
+ *     menu tree.
+ *   - is_collapsed: TRUE if the link has children within the current menu tree
+ *     that are not currently visible.
+ *   - in_active_trail: TRUE if the link is in the active trail.
+ */
+#}
+{% import _self as menus %}
+
+{#
+  We call a macro which calls itself to render the full tree.
+  @see http://twig.sensiolabs.org/doc/tags/macro.html
+#}
+{{ menus.menu_links(items, attributes, 0) }}
+
+{% macro menu_links(items, attributes, menu_level) %}
+  {% import _self as menus %}
+  {% if items %}
+    {% if menu_level == 0 %}
+<ul{{ attributes.addClass('nav') }}>
+  {% else %}
+  <ul class="menu">
+    {% endif %}
+    {% for item in items %}
+      {% set classes = [
+        'nav-item',
+        item.is_expanded ? 'menu-item--expanded',
+        item.is_collapsed ? 'menu-item--collapsed',
+        item.in_active_trail ? 'menu-item--active-trail',
+      ] %}
+      <li{{ item.attributes.addClass(classes) }}>
+        {% set link_classes = [
+          'nav-link',
+          item.in_active_trail ? 'active'
+        ] %}
+        {% if item.url.getOption('attributes') is not null %}
+          {% set link_attributes =  create_attribute(item.url.getOption('attributes')).addClass(link_classes) %}
+        {% else %}
+          {% set link_attributes =  create_attribute({'class': link_classes}) %}
+        {% endif %}
+
+        {{ link(item.title, item.url, link_attributes) }}
+        {% if item.below %}
+          {{ menus.menu_links(item.below, attributes, menu_level + 1) }}
+        {% endif %}
+      </li>
+    {% endfor %}
+  </ul>
+  {% endif %}
+  {% endmacro %}


### PR DESCRIPTION
In a subtheme I noticed some array to string conversion warnings when using a menu in one of the sidebars. After digging, I found out, barrio's menu.html.twig implementation of menu links is not consistent with the link_attributes module and also does not respect all link_attributes options. This should fix it for vartheme_bs4, maybe it is also a upstream solution